### PR TITLE
add option for specifying custom http client

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -31,12 +31,17 @@ type CloudflareAPI struct {
 }
 
 // NewCloudflareProvider creates a new Cloudflare DNS provider.
-func NewCloudflareProvider(ctx context.Context, zone string, credentialsData map[string]string, logger api.Logger) (*CloudflareAPI, error) {
+func NewCloudflareProvider(ctx context.Context, zone string, credentialsData map[string]string, logger api.Logger, ops ...Option) (*CloudflareAPI, error) {
 	token, ok := credentialsData["token"]
 	if !ok {
 		return nil, fmt.Errorf("missing token key from cloudflare dns provider credentials data")
 	}
-	api, err := cloudflare.NewWithAPIToken(token)
+	opts := getOptions()
+	apiOptions := []cloudflare.Option{}
+	if opts.client != nil {
+		apiOptions = append(apiOptions, cloudflare.HTTPClient(opts.client))
+	}
+	api, err := cloudflare.NewWithAPIToken(token, apiOptions...)
 	if err != nil {
 		return nil, err
 	}

--- a/dnsproviders.go
+++ b/dnsproviders.go
@@ -18,22 +18,43 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"net/http"
 
 	"github.com/edgexr/dnsproviders/api"
 )
 
-func GetProvider(ctx context.Context, typ api.ProviderType, zone string, credentialsData map[string]string, logger api.Logger) (api.Provider, error) {
+func GetProvider(ctx context.Context, typ api.ProviderType, zone string, credentialsData map[string]string, logger api.Logger, ops ...Option) (api.Provider, error) {
 	if logger == nil {
 		logger = slog.Default()
 	}
 
 	switch typ {
 	case api.CloudflareProvider:
-		return NewCloudflareProvider(ctx, zone, credentialsData, logger)
+		return NewCloudflareProvider(ctx, zone, credentialsData, logger, ops...)
 	case api.GoogleCloudDNSProvider:
-		return NewGoogleCloudDNSProvider(ctx, zone, credentialsData, logger)
+		return NewGoogleCloudDNSProvider(ctx, zone, credentialsData, logger, ops...)
 	case api.OpenTelekomCloudProvider:
-		return NewOtcProvider(ctx, zone, credentialsData, logger)
+		return NewOtcProvider(ctx, zone, credentialsData, logger, ops...)
 	}
 	return nil, errors.New("unknown dns provider " + string(typ))
+}
+
+type options struct {
+	client *http.Client
+}
+
+type Option func(opts *options)
+
+func WithHTTPClient(client *http.Client) Option {
+	return func(opts *options) {
+		opts.client = client
+	}
+}
+
+func getOptions(ops ...Option) options {
+	opts := options{}
+	for _, op := range ops {
+		op(&opts)
+	}
+	return opts
 }

--- a/googleclouddns.go
+++ b/googleclouddns.go
@@ -39,7 +39,7 @@ type CloudDNS struct {
 }
 
 // NewGoogleCloudDNS creates a new Google Cloud DNS provider
-func NewGoogleCloudDNSProvider(ctx context.Context, zone string, credentialsData map[string]string, logger api.Logger) (*CloudDNS, error) {
+func NewGoogleCloudDNSProvider(ctx context.Context, zone string, credentialsData map[string]string, logger api.Logger, ops ...Option) (*CloudDNS, error) {
 	project, ok := credentialsData[projectID]
 	if !ok {
 		return nil, fmt.Errorf("google cloud DNS credentials missing " + projectID)
@@ -48,8 +48,17 @@ func NewGoogleCloudDNSProvider(ctx context.Context, zone string, credentialsData
 	if err != nil {
 		return nil, err
 	}
+	apiOptions := []option.ClientOption{
+		option.WithCredentialsJSON(jsonData),
+	}
+
+	opts := getOptions()
+	if opts.client != nil {
+		apiOptions = append(apiOptions, option.WithHTTPClient(opts.client))
+	}
+
 	logger.InfoContext(ctx, "initializing google cloud DNS", "project", project)
-	api, err := dns.NewService(ctx, option.WithCredentialsJSON(jsonData))
+	api, err := dns.NewService(ctx, apiOptions...)
 	if err != nil {
 		return nil, err
 	}

--- a/otc.go
+++ b/otc.go
@@ -37,7 +37,7 @@ var (
 	ErrRecordNotFound = errors.New("could not find record by the given name")
 )
 
-func NewOtcProvider(_ context.Context, _ string, credentialsData map[string]string, logger api.Logger) (*OTC, error) {
+func NewOtcProvider(_ context.Context, _ string, credentialsData map[string]string, logger api.Logger, ops ...Option) (*OTC, error) {
 	for _, key := range []string{CredentialKeyRegion, CredentialKeyDomainName, CredentialKeyTenantName, CredentialKeyUsername, CredentialKeyPassword} {
 		if _, isSet := credentialsData[key]; !isSet {
 			return nil, fmt.Errorf("missing key %s is credentialData", key)
@@ -51,6 +51,10 @@ func NewOtcProvider(_ context.Context, _ string, credentialsData map[string]stri
 		Username:         credentialsData[CredentialKeyUsername],
 		Password:         credentialsData[CredentialKeyPassword],
 	})
+	opts := getOptions(ops...)
+	if opts.client != nil {
+		client.HTTPClient = *opts.client
+	}
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize authenticated client: %v", err)


### PR DESCRIPTION
In the case that the endpoint requires specific certs, or proxy config, or any other client/transport related customization, the dns provider now allows an option to specify a custom http client.